### PR TITLE
Add basic form builder

### DIFF
--- a/lib/twitter-bootstrap-markup-rails/components.rb
+++ b/lib/twitter-bootstrap-markup-rails/components.rb
@@ -3,6 +3,8 @@ module Twitter::Bootstrap::Markup::Rails
     autoload :Base, 'twitter-bootstrap-markup-rails/components/base'
     autoload :Alert, 'twitter-bootstrap-markup-rails/components/alert'
     autoload :InlineLabel, 'twitter-bootstrap-markup-rails/components/inline_label'
+    autoload :Form, 'twitter-bootstrap-markup-rails/components/form'
+    autoload :FormBuilder, 'twitter-bootstrap-markup-rails/components/form_builder'
   end
 end
 

--- a/lib/twitter-bootstrap-markup-rails/components/form.rb
+++ b/lib/twitter-bootstrap-markup-rails/components/form.rb
@@ -1,0 +1,14 @@
+module Twitter::Bootstrap::Markup::Rails::Components
+  class Form < Base
+    autoload :InputField, 'twitter-bootstrap-markup-rails/components/form/input_field'
+    autoload :Label, 'twitter-bootstrap-markup-rails/components/form/label'
+
+    include ActionView::Helpers::FormHelper
+
+    protected
+
+    def default_options
+      {}
+    end
+  end
+end

--- a/lib/twitter-bootstrap-markup-rails/components/form/input_field.rb
+++ b/lib/twitter-bootstrap-markup-rails/components/form/input_field.rb
@@ -1,0 +1,47 @@
+module Twitter::Bootstrap::Markup::Rails::Components
+  class Form::InputField < Form
+    attr_accessor :input_html, :label_html
+
+    def initialize(object_name, method, input_html, options = {})
+      super(options)
+      @input_html = input_html
+      @label_html = Label.new(object_name, method, options) if options[:label] || options[:label_text]
+    end
+
+    def to_s
+      output_buffer << content_tag(:div, :class => 'control-group') do
+        html = ''
+        html << label_html.to_s
+        html << content_tag(:div, :class => 'controls') do
+          build_input_wrapper
+        end
+        html.html_safe
+      end
+      super
+    end
+
+    private
+
+    def build_input_wrapper
+      if options[:add_on]
+        build_add_on_wrapper
+      else
+        input_html
+      end
+    end
+
+    def build_add_on_wrapper
+      content_tag(:div, :class => "input-#{options[:add_on][:position] || 'prepend'}") do
+        add_on = ''
+        add_on << input_html
+        add_on << content_tag(:span, :class => 'add-on') do
+          add_on_content = ''
+          add_on_content << content_tag(:i, '', :class => options[:add_on][:icon]) if options[:add_on][:icon]
+          add_on_content << options[:add_on][:text] if options[:add_on][:text]
+          add_on_content.html_safe
+        end
+        add_on.html_safe
+      end
+    end
+  end
+end

--- a/lib/twitter-bootstrap-markup-rails/components/form/label.rb
+++ b/lib/twitter-bootstrap-markup-rails/components/form/label.rb
@@ -1,0 +1,8 @@
+module Twitter::Bootstrap::Markup::Rails::Components
+  class Form::Label < Form
+    def initialize(object_name, method, options)
+      super(options)
+      output_buffer << label(object_name, method, options[:label_text], :class => 'control-label')
+    end
+  end
+end

--- a/lib/twitter-bootstrap-markup-rails/components/form_builder.rb
+++ b/lib/twitter-bootstrap-markup-rails/components/form_builder.rb
@@ -1,0 +1,13 @@
+module Twitter::Bootstrap::Markup::Rails::Components
+  class FormBuilder < ActionView::Helpers::FormBuilder
+    def text_field(method, options={})
+      input_html = super(method, options)
+      Form::InputField.new(object_name, method, input_html, options).to_s
+    end
+
+    def password_field(method, options={})
+      input_html = super(method, options)
+      Form::InputField.new(object_name, method, input_html, options).to_s
+    end
+  end
+end

--- a/lib/twitter-bootstrap-markup-rails/engine.rb
+++ b/lib/twitter-bootstrap-markup-rails/engine.rb
@@ -6,6 +6,7 @@ module Twitter::Bootstrap::Markup::Rails
       ActiveSupport.on_load(:action_view) do
         include Twitter::Bootstrap::Markup::Rails::Helpers::AlertHelpers
         include Twitter::Bootstrap::Markup::Rails::Helpers::InlineLabelHelpers
+        include Twitter::Bootstrap::Markup::Rails::Helpers::FormHelpers
       end
     end
   end

--- a/lib/twitter-bootstrap-markup-rails/helpers.rb
+++ b/lib/twitter-bootstrap-markup-rails/helpers.rb
@@ -2,6 +2,7 @@ module Twitter::Bootstrap::Markup::Rails
   module Helpers
     autoload :AlertHelpers, 'twitter-bootstrap-markup-rails/helpers/alert_helpers'
     autoload :InlineLabelHelpers, 'twitter-bootstrap-markup-rails/helpers/inline_label_helpers'
+    autoload :FormHelpers, 'twitter-bootstrap-markup-rails/helpers/form_helpers'
   end
 end
 

--- a/lib/twitter-bootstrap-markup-rails/helpers/form_helpers.rb
+++ b/lib/twitter-bootstrap-markup-rails/helpers/form_helpers.rb
@@ -1,0 +1,11 @@
+module Twitter::Bootstrap::Markup::Rails::Helpers
+  module FormHelpers
+    # Form builder
+    # TODO add documentation
+    def bootstrap_form_for(*args, &block)
+      options = args.extract_options!
+      options.reverse_merge!(:builder => Twitter::Bootstrap::Markup::Rails::Components::FormBuilder)
+      form_for(*(args + [options]), &block)
+    end
+  end
+end

--- a/spec/helpers/form_helpers_spec.rb
+++ b/spec/helpers/form_helpers_spec.rb
@@ -1,0 +1,114 @@
+# encoding: utf-8
+require 'spec_helper'
+
+describe Twitter::Bootstrap::Markup::Rails::Helpers::FormHelpers do
+  include BootstrapSpecHelper
+  include BootstrapFormMacros
+
+  describe "#bootstrap_form_for" do
+    it "should create a form tag" do
+      block = Proc.new {}
+      concat bootstrap_form_for 'an_object', :url => 'a_url', &block
+      output_buffer.should have_tag('form')
+    end
+
+    context "text_field" do
+      it "should wrap a text input within the magical div tags" do
+        build_bootstrap_form do |f|
+          f.text_field 'method'
+        end
+
+        output_buffer.should have_tag('div.control-group div.controls input[type=text]')
+      end
+
+      it "should add a label tag if :label is true" do
+        build_bootstrap_form do |f|
+          f.text_field 'method', :label => true
+        end
+
+        output_buffer.should have_tag('div.control-group') do |div|
+          div.should have_tag('label.control-label')
+          div.should have_tag('div.controls') do |div|
+            div.should have_tag('input')
+          end
+        end
+      end
+
+      it "should add a label tag with custom text if :label_text is specified" do
+        build_bootstrap_form do |f|
+          f.text_field 'method', :label_text => 'a custom label'
+        end
+
+        output_buffer.should have_tag('div.control-group') do |div|
+          div.should have_tag('label.control-label', :text => 'a custom label')
+          div.should have_tag('div.controls') do |div|
+            div.should have_tag('input')
+          end
+        end
+      end
+
+      context "add_on" do
+        it "should wrap the input in div.input-prepend if :add_on hash is specified" do
+          build_bootstrap_form do |f|
+            f.text_field 'method', :add_on => {}
+          end
+
+          output_buffer.should have_tag('div.control-group') do |div|
+            div.should have_tag('div.controls') do |div|
+              div.should have_tag('div.input-prepend') do |div|
+                div.should have_tag('input')
+              end
+            end
+          end
+        end
+
+        it "should wrap the input in div.input-append if :position is :append" do
+          build_bootstrap_form do |f|
+            f.text_field 'method', :add_on => {:position => :append}
+          end
+
+          output_buffer.should have_tag('div.control-group') do |div|
+            div.should have_tag('div.controls') do |div|
+              div.should have_tag('div.input-append') do |div|
+                div.should have_tag('input')
+              end
+            end
+          end
+        end
+
+        it "should add a span with text if :text is specified" do
+          build_bootstrap_form do |f|
+            f.text_field 'method', :add_on => {:text => 'a text'}
+          end
+
+          output_buffer.should have_tag('div.control-group') do |div|
+            div.should have_tag('div.controls') do |div|
+              div.should have_tag('div.input-prepend') do |div|
+                div.should have_tag('input')
+                div.should have_tag('span', :class => 'add-on', :text => 'a text')
+              end
+            end
+          end
+        end
+
+        it "should add a span with icon if :icon is specified" do
+          build_bootstrap_form do |f|
+            f.text_field 'method', :add_on => {:icon => 'icon-envelope'}
+          end
+
+          output_buffer.should have_tag('div.control-group') do |div|
+            div.should have_tag('div.controls') do |div|
+              div.should have_tag('div.input-prepend') do |div|
+                div.should have_tag('input')
+                div.should have_tag('span', :class => 'add-on') do |span|
+                  span.should have_tag('i', :class => 'icon-envelope')
+                end
+              end
+            end
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/spec/integration/action_view_spec.rb
+++ b/spec/integration/action_view_spec.rb
@@ -12,4 +12,8 @@ describe ActionView::Base do
   it "includes inline label helpers" do
     @view.ancestors.should include(Twitter::Bootstrap::Markup::Rails::Helpers::InlineLabelHelpers)
   end
+
+  it "includes inline form helpers" do
+    @view.ancestors.should include(Twitter::Bootstrap::Markup::Rails::Helpers::FormHelpers)
+  end
 end

--- a/spec/support/bootstrap_form_macros.rb
+++ b/spec/support/bootstrap_form_macros.rb
@@ -1,0 +1,8 @@
+module BootstrapFormMacros
+  def build_bootstrap_form(&block)
+    form_builder = bootstrap_form_for 'object', :url => 'url' do |f|
+      block.call f
+    end
+    concat form_builder
+  end
+end


### PR DESCRIPTION
This add a basic form builder and helper method bootstrap_form_for. It supports only text_field and password_field for now. I'm planning to do in the following days:

1) add support for other options and form elements
2) add documentation
