### PR TITLE
Add support for buttons and dropdowns

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,30 @@ Notice Inline Label:
     bootstrap_inline_label_notice_tag("Info")
     # => '<span class="label notice">Info</span>'
 
+Buttons:
+
+    bootstrap_button("Button Text", "#")
+    # => '<a class="btn" href="#">Button Text</a>'
+
+Dropdown Buttons:
+
+```
+bootstrap_button_dropdown do |b|
+    b.bootstrap_button "Button Title", "#"
+    b.link_to "First Dropdown Item", @item
+    b.link_to "Second Dropdown Item", @item2
+end
+# => '<div class="btn-group">
+        <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
+            Button Title
+            <span class="caret"></span>
+        </a>
+        <ul class="dropdown-menu">
+            <!-- dropdown menu links -->
+        </ul>
+      </div>'
+```
+
 Plugins
 ---
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Add to your `Gemfile`:
 
 * Alert messages
 * Inline labels
+* buttons
+* button dropdowns
 
 Documentation
 ---

--- a/lib/twitter-bootstrap-markup-rails.rb
+++ b/lib/twitter-bootstrap-markup-rails.rb
@@ -6,6 +6,8 @@ module Twitter
       module Rails
         require "twitter-bootstrap-markup-rails/version"
 
+        require "twitter-bootstrap-markup-rails/helper_collection"
+
         autoload :Helpers, "twitter-bootstrap-markup-rails/helpers"
         autoload :Components, "twitter-bootstrap-markup-rails/components"
 

--- a/lib/twitter-bootstrap-markup-rails/components.rb
+++ b/lib/twitter-bootstrap-markup-rails/components.rb
@@ -5,6 +5,8 @@ module Twitter::Bootstrap::Markup::Rails
     autoload :InlineLabel, 'twitter-bootstrap-markup-rails/components/inline_label'
     autoload :Form, 'twitter-bootstrap-markup-rails/components/form'
     autoload :FormBuilder, 'twitter-bootstrap-markup-rails/components/form_builder'
+    autoload :Button, 'twitter-bootstrap-markup-rails/components/button'
+    autoload :ButtonDropdown, 'twitter-bootstrap-markup-rails/components/button_dropdown'
   end
 end
 

--- a/lib/twitter-bootstrap-markup-rails/components/button.rb
+++ b/lib/twitter-bootstrap-markup-rails/components/button.rb
@@ -1,0 +1,66 @@
+module Twitter::Bootstrap::Markup::Rails::Components
+  class Button < Base
+    attr_reader :text
+
+    def initialize(text, link, options = {})
+      super
+      @text = text
+      @link = link
+    end
+
+    def to_s
+      html_text = ""
+      html_text << build_icon.html_safe << ' ' if options[:icon]
+      html_text << text
+      html_text << ' ' << build_caret.html_safe if options[:dropdown]
+
+      output_buffer << content_tag(:a, html_text.html_safe, build_tag_options).html_safe
+      super
+    end
+
+    private
+    def default_options
+      {
+        :class      => "btn",
+        :type       => [],
+        :disabled   => false,
+        :icon_white => false,
+        :dropdown   => false,
+        :id         => nil
+      }
+    end
+
+    def build_class
+      classes = [options[:class]]
+
+      if options[:type].is_a?(Array)
+        classes = classes | options[:type].map{|c| c.to_s}
+      else
+        classes << options[:type]
+      end
+
+      classes << 'dropdown-toggle' if options[:dropdown]
+      classes << 'disabled' if options[:disabled]
+
+      classes.join(" ")
+    end
+
+    def build_icon
+      klass = options[:icon]
+      klass << ' icon-white' if options[:icon_white]
+      content_tag(:i, nil, :class => klass)
+    end
+
+    def build_caret
+      content_tag(:span, nil, :class => 'caret')
+    end
+
+    def build_tag_options
+      ops = {:href => @link, :class => build_class}
+      ops[:"data-toggle"] = 'dropdown' if options[:dropdown]
+      ops[:id] = options[:id] if options[:id]
+      ops
+    end
+  end
+end
+

--- a/lib/twitter-bootstrap-markup-rails/components/button_dropdown.rb
+++ b/lib/twitter-bootstrap-markup-rails/components/button_dropdown.rb
@@ -1,0 +1,44 @@
+module Twitter::Bootstrap::Markup::Rails::Components
+  class ButtonDropdown < Base
+    attr_reader :collection
+
+    def initialize(elements, options = {})
+      super
+      @elements = elements
+    end
+
+    def to_s
+      output_buffer << content_tag(:div, :class => 'btn-group') do
+        html=''
+        html << build_dropdown
+
+        html << content_tag(:ul, :class => 'dropdown-menu') do
+          menu = ''
+          @elements.each do |e|
+            menu << content_tag(:li, e.to_s)
+          end
+          menu.html_safe
+        end
+
+        html.html_safe
+      end
+      super
+    end
+
+    private
+    def default_options
+      {}
+    end
+
+    def build_dropdown
+      if @elements.size > 0
+        dropdown = @elements.shift
+        dropdown.options[:dropdown] = true
+        dropdown.to_s
+      else
+        ''
+      end
+    end
+  end
+end
+

--- a/lib/twitter-bootstrap-markup-rails/engine.rb
+++ b/lib/twitter-bootstrap-markup-rails/engine.rb
@@ -7,6 +7,7 @@ module Twitter::Bootstrap::Markup::Rails
         include Twitter::Bootstrap::Markup::Rails::Helpers::AlertHelpers
         include Twitter::Bootstrap::Markup::Rails::Helpers::InlineLabelHelpers
         include Twitter::Bootstrap::Markup::Rails::Helpers::FormHelpers
+        include Twitter::Bootstrap::Markup::Rails::Helpers::ButtonHelpers
       end
     end
   end

--- a/lib/twitter-bootstrap-markup-rails/helper_collection.rb
+++ b/lib/twitter-bootstrap-markup-rails/helper_collection.rb
@@ -1,0 +1,56 @@
+module Twitter::Bootstrap::Markup::Rails
+  class HelperCollection
+    attr_accessor :calls, :view
+
+    def initialize(view)
+      @view = view
+      @calls = []
+    end
+
+    def method_missing(symbol, *args, &block)
+      @calls << HelperMethodCall.new(@view, symbol, args, block)
+    end
+
+    def each
+      @calls.each do |c|
+        yield c
+      end
+    end
+
+    def [](x)
+      @calls[x]
+    end
+
+    def size
+      @calls.size
+    end
+
+    def shift
+      @calls.shift
+    end
+  end
+
+  class HelperMethodCall
+    attr_accessor :method, :options, :args
+
+    def initialize(view, symbol, args, block)
+      @view = view
+      @method = symbol
+      @options = args.extract_options!
+      @args = args
+      @block = block
+    end
+
+    def to_s
+      args = @args
+      args << @options
+
+      if @block
+        @view.send(@method, *args, &@block).html_safe
+      else
+        @view.send(@method, *args).html_safe
+      end
+    end
+
+  end
+end

--- a/lib/twitter-bootstrap-markup-rails/helpers.rb
+++ b/lib/twitter-bootstrap-markup-rails/helpers.rb
@@ -3,6 +3,7 @@ module Twitter::Bootstrap::Markup::Rails
     autoload :AlertHelpers, 'twitter-bootstrap-markup-rails/helpers/alert_helpers'
     autoload :InlineLabelHelpers, 'twitter-bootstrap-markup-rails/helpers/inline_label_helpers'
     autoload :FormHelpers, 'twitter-bootstrap-markup-rails/helpers/form_helpers'
+    autoload :ButtonHelpers, 'twitter-bootstrap-markup-rails/helpers/button_helpers'
   end
 end
 

--- a/lib/twitter-bootstrap-markup-rails/helpers/button_helpers.rb
+++ b/lib/twitter-bootstrap-markup-rails/helpers/button_helpers.rb
@@ -1,0 +1,57 @@
+# encoding: utf-8
+
+module Twitter::Bootstrap::Markup::Rails::Helpers
+  module ButtonHelpers
+    # Render a bootstrap button
+    #
+    # @param [String] text for the button face
+    # @param [String] link for the button href
+    # @param [Hash] options hash containing options (default: {}):
+    #           :type       - Additional button type(s). For one, just specify a string, but
+    #                         you can also pass an array (of sym or str) for multiple classes
+    #           :disabled   - Will disable the button if set to true
+    #           :icon       - Specify an icon class from bootstrap to prepend
+    #           :icon_white - Specify true if you want the icon to be white
+    #           :id         - Assign an ID to the button
+    #
+    # Examples
+    #
+    #   bootstrap_button 'Search', '#', :type => 'btn-primary', :icon => 'icon-search'
+    #
+    def bootstrap_button(text, link, options = {})
+      Twitter::Bootstrap::Markup::Rails::Components::Button.new(
+        text,
+        link,
+        options
+      ).to_s
+    end
+
+    # Render a dropdown button
+    #
+    # @param [Hash] options hash containing options (default: {}):
+    #
+    # Examples
+    #
+    #   bootstrap_button_dropdown do |e|
+    #     e.bootstrap_button "Button Title", "http://google.com"
+    #     e.link_to "Blah", @blah
+    #   end
+    #
+    # Returns HTML String for the dropdown
+    #
+    def bootstrap_button_dropdown(options = {})
+      # Elements will hold every call made to this block. Self is passed in so the
+      # elements can be sent to it in order to be evaluated
+      elements = Twitter::Bootstrap::Markup::Rails::HelperCollection.new(self)
+
+      yield elements
+
+      Twitter::Bootstrap::Markup::Rails::Components::ButtonDropdown.new(
+        elements,
+        options
+      ).to_s
+    end
+
+  end
+end
+

--- a/spec/helpers/button_helpers_spec.rb
+++ b/spec/helpers/button_helpers_spec.rb
@@ -1,0 +1,79 @@
+# encoding: utf-8
+require 'spec_helper'
+
+describe Twitter::Bootstrap::Markup::Rails::Helpers::ButtonHelpers do
+  include BootstrapSpecHelper
+  include BootstrapButtonMacros
+
+  describe "#bootstrap_button" do
+    before do
+      @output_buffer = ''
+    end
+
+    it "should create a button with the btn class" do
+      concat bootstrap_button("Text", "#")
+      output_buffer.should have_tag('a.btn')
+    end
+
+    it "should have text" do
+      concat bootstrap_button("Text", "#")
+      output_buffer.should have_tag('a', /Text/)
+    end
+
+    it "should link to the specified url" do
+      concat bootstrap_button("Text", "http://example.test")
+      output_buffer.should have_tag("a[href='http://example.test']")
+    end
+
+    it "should have disabled class when :disabled is true" do
+      concat bootstrap_button("Text", "#", :disabled => true)
+      output_buffer.should have_tag("a.disabled")
+    end
+
+    it "should add an additional class when :type is a string" do
+      concat bootstrap_button("Text", "#", :type => 'test')
+      output_buffer.should have_tag("a.test")
+    end
+
+    it "should add additional classes when :type is an array" do
+      concat bootstrap_button("Text", "#", :type => ['test1', 'test2'])
+      output_buffer.should have_tag("a.test1")
+      output_buffer.should have_tag("a.test2")
+    end
+
+    it "should add an icon when :icon is specified" do
+      concat bootstrap_button("Text", "#", :icon => 'icon-search')
+      output_buffer.should have_tag("a.btn i.icon-search")
+    end
+
+    it "should add a white icon when :icon_white is true" do
+      concat bootstrap_button("Text", "#", :icon => 'icon-search', :icon_white => true)
+      output_buffer.should have_tag("a.btn i.icon-search")
+      output_buffer.should have_tag("a.btn i.icon-white")
+    end
+
+    it "should add an id when :id is specified" do
+      concat bootstrap_button("Text", "#", :id => "foo")
+      output_buffer.should have_tag("a#foo")
+    end
+  end
+
+
+  describe "#bootstrap_button_dropdown" do
+    before do
+      @output_buffer = ''
+    end
+
+    it "should create a dropdown button when called with a button and one (or more) links" do
+      build_bootstrap_button_dropdown do |d|
+        d.bootstrap_button "Button Text", "#"
+        d.link_to "Link Text", "#"
+      end
+
+      output_buffer.should have_tag('div.btn-group') do |div|
+        div.should have_tag('a.btn')
+        div.should have_tag('ul.dropdown-menu a')
+      end
+    end
+  end
+end

--- a/spec/support/bootstrap_button_macros.rb
+++ b/spec/support/bootstrap_button_macros.rb
@@ -1,0 +1,8 @@
+module BootstrapButtonMacros
+  def build_bootstrap_button_dropdown(&block)
+    dropdown = bootstrap_button_dropdown do |d|
+      block.call d
+    end
+    concat dropdown
+  end
+end


### PR DESCRIPTION
I have added some support for buttons and dropdowns. Usage is documented in the new button_helpers file.

In order to accomplish the button dropdown, I had to do a little metaprogramming. You'll notice the new "HelperCollection." This is a collection of method calls to any rails helpers. Since a button group is essential a group of various types of objects (a button followed by links), I implemented it as a block that takes a series of method calls. This is quite elegant I think, for instance:

``` ruby
bootstrap_button_dropdown do |b|
  b.bootstrap_button "Button Title", "#"
  b.link_to "First Dropdown Item", @item
  b.link_to "Second Dropdown Item", @item2
end
```

Also note I am submitting future pull requests from my company, Inigral, rather than my personal github. But it's still me, @djabbour!
