### PR TITLE
Add support for Navigation Lists

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --order rand
+--color

--- a/README.md
+++ b/README.md
@@ -92,6 +92,68 @@ end
       </div>'
 ```
 
+Navigation lists:
+
+Basic tabs example:
+
+    bootstrap_navigation do |nav|
+      nav.link_to "Nav1", "/link1", :active_nav => true
+      nav.link_to "Nav2", "/link2"
+    end
+    # => <ul class="nav nav-tabs">
+           <li class="active">
+             <a href="/link1">Nav1</a>
+           </li>
+           <li>
+             <a href="/link2">Nav2</a>
+           </li>
+         </ul>
+
+Basic pills example:
+
+    bootstrap_navigation(:type => "pills") do |nav|
+      nav.link_to "Nav1", "/link1"
+      nav.link_to "Nav2", "/link2", :active_nav => true
+    end
+    # => <ul class="nav nav-pills">
+           <li>
+             <a href="/link1">Nav1</a>
+           </li>
+           <li class="active">
+             <a href="/link2">Nav2</a>
+           </li>
+         </ul>
+
+Stacked tabs example:
+
+    bootstrap_navigation(:type => "tabs", :stacked => true) do |nav|
+      nav.link_to "Nav1", "/link1", :active_nav => true
+      nav.link_to "Nav2", "/link2"
+    end
+    # => <ul class="nav nav-tabs nav-stacked">
+           <li class="active">
+             <a href="/link1">Nav1</a>
+           </li>
+           <li>
+             <a href="/link2">Nav2</a>
+           </li>
+         </ul>
+
+Stacked pills example:
+
+    bootstrap_navigation(:type => "pills", :stacked => true) do |nav|
+      nav.link_to "Nav1", "/link1"
+      nav.link_to "Nav2", "/link2", :active_nav => true
+    end
+    # => <ul class="nav nav-pills nav-stacked">
+           <li>
+             <a href="/link1">Nav1</a>
+           </li>
+           <li class="active">
+             <a href="/link2">Nav2</a>
+           </li>
+         </ul>
+
 Plugins
 ---
 

--- a/lib/twitter-bootstrap-markup-rails/components.rb
+++ b/lib/twitter-bootstrap-markup-rails/components.rb
@@ -7,6 +7,7 @@ module Twitter::Bootstrap::Markup::Rails
     autoload :FormBuilder, 'twitter-bootstrap-markup-rails/components/form_builder'
     autoload :Button, 'twitter-bootstrap-markup-rails/components/button'
     autoload :ButtonDropdown, 'twitter-bootstrap-markup-rails/components/button_dropdown'
+    autoload :Navigation, 'twitter-bootstrap-markup-rails/components/navigation'
   end
 end
 

--- a/lib/twitter-bootstrap-markup-rails/components/navigation.rb
+++ b/lib/twitter-bootstrap-markup-rails/components/navigation.rb
@@ -12,7 +12,8 @@ module Twitter::Bootstrap::Markup::Rails::Components
         html = ""
 
         @elements.each do |e|
-          html << content_tag(:li, e.to_s)
+          html_class = build_html_class(e)
+          html << content_tag(:li, e.to_s, html_class)
         end
 
         html.html_safe
@@ -21,8 +22,18 @@ module Twitter::Bootstrap::Markup::Rails::Components
     end
 
     private
+
     def default_options
       {}
+    end
+
+    def build_html_class(element)
+      html_class = {}
+      if element.options[:active_nav]
+        element.options.reject! {|k,v| k == :active_nav }
+        html_class = { :class => "active" }
+      end
+      html_class
     end
 
     def build_class

--- a/lib/twitter-bootstrap-markup-rails/components/navigation.rb
+++ b/lib/twitter-bootstrap-markup-rails/components/navigation.rb
@@ -27,7 +27,7 @@ module Twitter::Bootstrap::Markup::Rails::Components
 
     def build_class
       classes = %w( nav )
-      classes << "nav-#{options[:type]}" if options[:type]
+      classes << "nav-#{ options[:type] || "tabs" }"
       classes << "nav-stacked" if options[:stacked]
       classes.join(" ")
     end

--- a/lib/twitter-bootstrap-markup-rails/components/navigation.rb
+++ b/lib/twitter-bootstrap-markup-rails/components/navigation.rb
@@ -1,0 +1,36 @@
+module Twitter::Bootstrap::Markup::Rails::Components
+  class Navigation < Base
+    attr_reader :collection
+
+    def initialize(elements, options = {})
+      super
+      @elements = elements
+    end
+
+    def to_s
+      output_buffer << content_tag(:ul, :class => build_class) do
+        html = ""
+
+        @elements.each do |e|
+          html << content_tag(:li, e.to_s)
+        end
+
+        html.html_safe
+      end
+      super
+    end
+
+    private
+    def default_options
+      {}
+    end
+
+    def build_class
+      classes = %w( nav )
+      classes << "nav-#{options[:type]}" if options[:type]
+      classes << "nav-stacked" if options[:stacked]
+      classes.join(" ")
+    end
+  end
+end
+

--- a/lib/twitter-bootstrap-markup-rails/engine.rb
+++ b/lib/twitter-bootstrap-markup-rails/engine.rb
@@ -8,6 +8,7 @@ module Twitter::Bootstrap::Markup::Rails
         include Twitter::Bootstrap::Markup::Rails::Helpers::InlineLabelHelpers
         include Twitter::Bootstrap::Markup::Rails::Helpers::FormHelpers
         include Twitter::Bootstrap::Markup::Rails::Helpers::ButtonHelpers
+        include Twitter::Bootstrap::Markup::Rails::Helpers::NavigationHelpers
       end
     end
   end

--- a/lib/twitter-bootstrap-markup-rails/helpers.rb
+++ b/lib/twitter-bootstrap-markup-rails/helpers.rb
@@ -4,6 +4,7 @@ module Twitter::Bootstrap::Markup::Rails
     autoload :InlineLabelHelpers, 'twitter-bootstrap-markup-rails/helpers/inline_label_helpers'
     autoload :FormHelpers, 'twitter-bootstrap-markup-rails/helpers/form_helpers'
     autoload :ButtonHelpers, 'twitter-bootstrap-markup-rails/helpers/button_helpers'
+    autoload :NavigationHelpers, 'twitter-bootstrap-markup-rails/helpers/navigation_helpers'
   end
 end
 

--- a/lib/twitter-bootstrap-markup-rails/helpers/navigation_helpers.rb
+++ b/lib/twitter-bootstrap-markup-rails/helpers/navigation_helpers.rb
@@ -1,0 +1,19 @@
+# encoding: utf-8
+
+module Twitter::Bootstrap::Markup::Rails::Helpers
+  module NavigationHelpers
+
+    def bootstrap_navigation(options = {})
+      elements = Twitter::Bootstrap::Markup::Rails::HelperCollection.new(self)
+
+      yield elements
+
+      Twitter::Bootstrap::Markup::Rails::Components::Navigation.new(
+        elements,
+        options
+      ).to_s
+    end
+
+  end
+end
+

--- a/lib/twitter-bootstrap-markup-rails/helpers/navigation_helpers.rb
+++ b/lib/twitter-bootstrap-markup-rails/helpers/navigation_helpers.rb
@@ -3,6 +3,20 @@
 module Twitter::Bootstrap::Markup::Rails::Helpers
   module NavigationHelpers
 
+    # Render a navigation list
+    #
+    # @param [Hash] options hash containing options (default: {}):
+    #            :type    - could be either 'tabs' or 'pills'. Default is 'tabs'.
+    #            :stacked - if true, renders the navigation list in stacked mode.
+    #
+    # Examples
+    #
+    #   bootstrap_navigation(:type => "tabs", :stacked => true) do |nav|
+    #     nav.link_to "Nav1", "/link1", :active_nav => true
+    #     nav.link_to "Nav2", "/link2"
+    #   end
+    #
+    # Returns HTML String for the navigation list
     def bootstrap_navigation(options = {})
       elements = Twitter::Bootstrap::Markup::Rails::HelperCollection.new(self)
 

--- a/spec/helpers/navigation_helpers_spec.rb
+++ b/spec/helpers/navigation_helpers_spec.rb
@@ -12,12 +12,12 @@ describe Twitter::Bootstrap::Markup::Rails::Helpers::NavigationHelpers do
 
     it "should create a basic navigation list of type tabs" do
       build_bootstrap_navigation do |nav|
-        nav.link_to "Nav1", "/link1"
+        nav.link_to "Nav1", "/link1", :active_nav => true
         nav.link_to "Nav2", "/link2"
       end
 
       output_buffer.should have_tag('ul.nav.nav-tabs') do |ul|
-        ul.should have_tag('li a[@href="/link1"]')
+        ul.should have_tag('li[@class="active"] a[@href="/link1"]')
         ul.should have_tag('li a[@href="/link1"]')
       end
     end
@@ -25,23 +25,23 @@ describe Twitter::Bootstrap::Markup::Rails::Helpers::NavigationHelpers do
     it "should create a basic navigation list of type pills" do
       build_bootstrap_navigation(:type => "pills") do |nav|
         nav.link_to "Nav1", "/link1"
-        nav.link_to "Nav2", "/link2"
+        nav.link_to "Nav2", "/link2", :active_nav => true
       end
 
       output_buffer.should have_tag('ul.nav.nav-pills') do |ul|
         ul.should have_tag('li a[@href="/link1"]')
-        ul.should have_tag('li a[@href="/link1"]')
+        ul.should have_tag('li[class="active"] a[@href="/link2"]')
       end
     end
 
     it "should create a vertical navigation list of type tabs when called with a list of links" do
       build_bootstrap_navigation(:type => "tabs", :stacked => true) do |nav|
-        nav.link_to "Nav1", "/link1"
+        nav.link_to "Nav1", "/link1", :active_nav => true
         nav.link_to "Nav2", "/link2"
       end
 
       output_buffer.should have_tag('ul.nav.nav-tabs.nav-stacked') do |ul|
-        ul.should have_tag('li a[@href="/link1"]')
+        ul.should have_tag('li[@class="active"] a[@href="/link1"]')
         ul.should have_tag('li a[@href="/link1"]')
       end
     end
@@ -49,12 +49,12 @@ describe Twitter::Bootstrap::Markup::Rails::Helpers::NavigationHelpers do
     it "should create a vertical navigation list of type pills when called with a list of links" do
       build_bootstrap_navigation(:type => "pills", :stacked => true) do |nav|
         nav.link_to "Nav1", "/link1"
-        nav.link_to "Nav2", "/link2"
+        nav.link_to "Nav2", "/link2", :active_nav => true
       end
 
       output_buffer.should have_tag('ul.nav.nav-pills.nav-stacked') do |ul|
         ul.should have_tag('li a[@href="/link1"]')
-        ul.should have_tag('li a[@href="/link1"]')
+        ul.should have_tag('li[@class="active"] a[@href="/link2"]')
       end
     end
   end

--- a/spec/helpers/navigation_helpers_spec.rb
+++ b/spec/helpers/navigation_helpers_spec.rb
@@ -10,13 +10,49 @@ describe Twitter::Bootstrap::Markup::Rails::Helpers::NavigationHelpers do
       @output_buffer = ''
     end
 
-    it "should create a navigation list when called with a list of links" do
+    it "should create a basic navigation list of type tabs" do
+      build_bootstrap_navigation do |nav|
+        nav.link_to "Nav1", "/link1"
+        nav.link_to "Nav2", "/link2"
+      end
+
+      output_buffer.should have_tag('ul.nav.nav-tabs') do |ul|
+        ul.should have_tag('li a[@href="/link1"]')
+        ul.should have_tag('li a[@href="/link1"]')
+      end
+    end
+
+    it "should create a basic navigation list of type pills" do
+      build_bootstrap_navigation(:type => "pills") do |nav|
+        nav.link_to "Nav1", "/link1"
+        nav.link_to "Nav2", "/link2"
+      end
+
+      output_buffer.should have_tag('ul.nav.nav-pills') do |ul|
+        ul.should have_tag('li a[@href="/link1"]')
+        ul.should have_tag('li a[@href="/link1"]')
+      end
+    end
+
+    it "should create a vertical navigation list of type tabs when called with a list of links" do
       build_bootstrap_navigation(:type => "tabs", :stacked => true) do |nav|
         nav.link_to "Nav1", "/link1"
         nav.link_to "Nav2", "/link2"
       end
 
       output_buffer.should have_tag('ul.nav.nav-tabs.nav-stacked') do |ul|
+        ul.should have_tag('li a[@href="/link1"]')
+        ul.should have_tag('li a[@href="/link1"]')
+      end
+    end
+
+    it "should create a vertical navigation list of type pills when called with a list of links" do
+      build_bootstrap_navigation(:type => "pills", :stacked => true) do |nav|
+        nav.link_to "Nav1", "/link1"
+        nav.link_to "Nav2", "/link2"
+      end
+
+      output_buffer.should have_tag('ul.nav.nav-pills.nav-stacked') do |ul|
         ul.should have_tag('li a[@href="/link1"]')
         ul.should have_tag('li a[@href="/link1"]')
       end

--- a/spec/helpers/navigation_helpers_spec.rb
+++ b/spec/helpers/navigation_helpers_spec.rb
@@ -1,0 +1,25 @@
+# encoding: utf-8
+require 'spec_helper'
+
+describe Twitter::Bootstrap::Markup::Rails::Helpers::NavigationHelpers do
+  include BootstrapSpecHelper
+  include BootstrapNavigationMacros
+
+  describe "#bootstrap_navigation" do
+    before do
+      @output_buffer = ''
+    end
+
+    it "should create a navigation list when called with a list of links" do
+      build_bootstrap_navigation(:type => "tabs", :stacked => true) do |nav|
+        nav.link_to "Nav1", "/link1"
+        nav.link_to "Nav2", "/link2"
+      end
+
+      output_buffer.should have_tag('ul.nav.nav-tabs.nav-stacked') do |ul|
+        ul.should have_tag('li a[@href="/link1"]')
+        ul.should have_tag('li a[@href="/link1"]')
+      end
+    end
+  end
+end

--- a/spec/integration/action_view_spec.rb
+++ b/spec/integration/action_view_spec.rb
@@ -16,4 +16,8 @@ describe ActionView::Base do
   it "includes inline form helpers" do
     @view.ancestors.should include(Twitter::Bootstrap::Markup::Rails::Helpers::FormHelpers)
   end
+
+  it "includes inline form helpers" do
+    @view.ancestors.should include(Twitter::Bootstrap::Markup::Rails::Helpers::NavigationHelpers)
+  end
 end

--- a/spec/support/bootstrap_navigation_macros.rb
+++ b/spec/support/bootstrap_navigation_macros.rb
@@ -1,0 +1,8 @@
+module BootstrapNavigationMacros
+  def build_bootstrap_navigation(options, &block)
+    nav = bootstrap_navigation(options) do |d|
+      block.call d
+    end
+    concat nav
+  end
+end

--- a/spec/support/bootstrap_navigation_macros.rb
+++ b/spec/support/bootstrap_navigation_macros.rb
@@ -1,5 +1,5 @@
 module BootstrapNavigationMacros
-  def build_bootstrap_navigation(options, &block)
+  def build_bootstrap_navigation(options = {}, &block)
     nav = bootstrap_navigation(options) do |d|
       block.call d
     end

--- a/twitter-bootstrap-markup-rails.gemspec
+++ b/twitter-bootstrap-markup-rails.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rspec_tag_matchers", ">= 1.0"
   gem.add_development_dependency "rake"
   gem.add_development_dependency 'yard'
+  gem.add_development_dependency 'redcarpet'
   gem.add_development_dependency 'yard-tomdoc'
   gem.add_development_dependency 'simple-navigation'
 end


### PR DESCRIPTION
Hi Piotr,

I added support for [Navigation Lists](http://twitter.github.com/bootstrap/components.html#navs).
Please have a look at the examples in the README. Just a quick one:

```
bootstrap_navigation do |nav|
  nav.link_to "Nav1", "/link1", :active_nav => true
  nav.link_to "Nav2", "/link2"
end
```

which results in the following html:

```
<ul class="nav nav-tabs">
  <li class="active">
    <a href="/link1">Nav1</a>
  </li>
  <li>
    <a href="/link2">Nav2</a>
  </li>
</ul>
```

I also added two minor changes:
- added color to rspec :)
- added redcarpet as a development dependency, otherwise `bundle exec rake yard` fails (at least under ruby 1.9.3).

Do you agree these changes?
