### PR TITLE
Adding support for html_options

### DIFF
--- a/lib/twitter-bootstrap-markup-rails/components/alert.rb
+++ b/lib/twitter-bootstrap-markup-rails/components/alert.rb
@@ -8,7 +8,7 @@ module Twitter::Bootstrap::Markup::Rails::Components
     end
 
     def to_s
-      output_buffer << content_tag(:div, :class => build_class) do
+      output_buffer << content_tag(:div, build_div_options) do
         html = ""
         html << build_close_tag.html_safe   if options[:close]
         html << build_heading_tag.html_safe if options[:heading]
@@ -21,12 +21,13 @@ module Twitter::Bootstrap::Markup::Rails::Components
     private
     def default_options
       {
-        :class   => "alert",
-        :block   => false,
-        :close   => true,
-        :heading => nil,
-        :dismiss => true,
-        :type    => nil,
+        :class        => "alert",
+        :block        => false,
+        :close        => true,
+        :heading      => nil,
+        :dismiss      => true,
+        :type         => nil,
+        :html_options => {}
       }
     end
 
@@ -50,6 +51,11 @@ module Twitter::Bootstrap::Markup::Rails::Components
       opts = { :class => "close" }
       opts["data-dismiss"] = "alert" if options[:dismiss]
       opts
+    end
+
+    def build_div_options
+      opts = { :class => build_class }
+      opts.reverse_merge(options[:html_options])
     end
 
     def build_class

--- a/lib/twitter-bootstrap-markup-rails/components/button.rb
+++ b/lib/twitter-bootstrap-markup-rails/components/button.rb
@@ -21,12 +21,13 @@ module Twitter::Bootstrap::Markup::Rails::Components
     private
     def default_options
       {
-        :class      => "btn",
-        :type       => [],
-        :disabled   => false,
-        :icon_white => false,
-        :dropdown   => false,
-        :id         => nil
+        :class        => "btn",
+        :type         => [],
+        :disabled     => false,
+        :icon_white   => false,
+        :dropdown     => false,
+        :id           => nil,
+        :html_options => {}
       }
     end
 
@@ -59,8 +60,7 @@ module Twitter::Bootstrap::Markup::Rails::Components
       ops = {:href => @link, :class => build_class}
       ops[:"data-toggle"] = 'dropdown' if options[:dropdown]
       ops[:id] = options[:id] if options[:id]
-      ops
+      ops.reverse_merge(options[:html_options])
     end
   end
 end
-

--- a/lib/twitter-bootstrap-markup-rails/components/inline_label.rb
+++ b/lib/twitter-bootstrap-markup-rails/components/inline_label.rb
@@ -8,15 +8,16 @@ module Twitter::Bootstrap::Markup::Rails::Components
     end
 
     def to_s
-      output_buffer << content_tag(:span, message, :class => build_class).html_safe
+      output_buffer << content_tag(:span, message, build_tag_options).html_safe
       super
     end
 
     private
     def default_options
       {
-        :class   => "label",
-        :type    => nil
+        :class        => "label",
+        :type         => nil,
+        :html_options => {}
       }
     end
 
@@ -24,6 +25,11 @@ module Twitter::Bootstrap::Markup::Rails::Components
       classes = [options[:class]]
       classes << options[:type] if options[:type]
       classes.join(" ")
+    end
+
+    def build_tag_options
+      ops = {:class => build_class}
+      ops.reverse_merge(options[:html_options])
     end
   end
 end

--- a/lib/twitter-bootstrap-markup-rails/helpers/alert_helpers.rb
+++ b/lib/twitter-bootstrap-markup-rails/helpers/alert_helpers.rb
@@ -6,11 +6,12 @@ module Twitter::Bootstrap::Markup::Rails::Helpers
     #
     # @param [String] message message to be displayed
     # @param [Hash] options hash containing options (default: {}):
-    #           :block   - The Boolean whether to display as a block (optional)
-    #           :close   - The Boolean whether to render close button
-    #           :heading - The String heading message to render
-    #           :dismiss - The Boolean whether to add dismiss attribute
-    #           :type    - The String type of alert to display: error, success or info
+    #           :block        - The Boolean whether to display as a block (optional)
+    #           :close        - The Boolean whether to render close button
+    #           :heading      - The String heading message to render
+    #           :dismiss      - The Boolean whether to add dismiss attribute
+    #           :type         - The String type of alert to display: error, success or info
+    #           :html_options - Any additional HTML options desired on the alert DIV.
     #
     # Examples
     #

--- a/lib/twitter-bootstrap-markup-rails/helpers/button_helpers.rb
+++ b/lib/twitter-bootstrap-markup-rails/helpers/button_helpers.rb
@@ -7,12 +7,14 @@ module Twitter::Bootstrap::Markup::Rails::Helpers
     # @param [String] text for the button face
     # @param [String] link for the button href
     # @param [Hash] options hash containing options (default: {}):
-    #           :type       - Additional button type(s). For one, just specify a string, but
-    #                         you can also pass an array (of sym or str) for multiple classes
-    #           :disabled   - Will disable the button if set to true
-    #           :icon       - Specify an icon class from bootstrap to prepend
-    #           :icon_white - Specify true if you want the icon to be white
-    #           :id         - Assign an ID to the button
+    #           :type         - Additional button type(s). For one, just specify a string, but
+    #                           you can also pass an array (of sym or str) for multiple classes
+    #           :disabled     - Will disable the button if set to true
+    #           :icon         - Specify an icon class from bootstrap to prepend
+    #           :icon_white   - Specify true if you want the icon to be white
+    #           :id           - Assign an ID to the button
+    #           :html_options - Any additional options you'd like to pass to the content_tag that will be created
+    #                           for this button's a tag (for instance :target can be specified in :html_options).
     #
     # Examples
     #

--- a/lib/twitter-bootstrap-markup-rails/helpers/inline_label_helpers.rb
+++ b/lib/twitter-bootstrap-markup-rails/helpers/inline_label_helpers.rb
@@ -5,7 +5,9 @@ module Twitter::Bootstrap::Markup::Rails::Helpers
     #
     # @param [String] message message to be displayed
     # @param [Hash] options hash containing options (default: {}):
-    #           :type    - The String type of alert to display: success warning important notice
+    #           :type         - The String type of alert to display: success warning important notice
+    #           :html_options - Any additional options you'd like to pass to the span tag that will be created
+    #                           for this label (for instance :"data-whatever" can be specified in :html_options).
     #
     # Examples
     #

--- a/spec/helpers/alert_helpers_spec.rb
+++ b/spec/helpers/alert_helpers_spec.rb
@@ -49,6 +49,11 @@ describe Twitter::Bootstrap::Markup::Rails::Helpers::AlertHelpers do
       concat bootstrap_alert_tag("Message", :heading => "Heading1", :block => false)
       output_buffer.should have_tag('div strong', /Heading1/)
     end
+
+    it "should add html_options to the resulting DIV tag when specified" do
+      concat bootstrap_alert_tag("Message", :html_options => {:"data-test" => "42"})
+      output_buffer.should have_tag("div[data-test='42']")
+    end
   end
 
   %w(error success info).each do |type|

--- a/spec/helpers/button_helpers_spec.rb
+++ b/spec/helpers/button_helpers_spec.rb
@@ -56,6 +56,11 @@ describe Twitter::Bootstrap::Markup::Rails::Helpers::ButtonHelpers do
       concat bootstrap_button("Text", "#", :id => "foo")
       output_buffer.should have_tag("a#foo")
     end
+
+    it "should add html_options to the resulting a tag when specified" do
+      concat bootstrap_button("Text", "#", :html_options => {:target => "_top"})
+      output_buffer.should have_tag("a[target='_top']")
+    end
   end
 
 

--- a/spec/helpers/inline_label_helpers_spec.rb
+++ b/spec/helpers/inline_label_helpers_spec.rb
@@ -17,6 +17,11 @@ describe Twitter::Bootstrap::Markup::Rails::Helpers::InlineLabelHelpers do
       concat bootstrap_inline_label_tag("Hi There")
       output_buffer.should have_tag("span", "Hi There")
     end
+
+    it "should add html_options to the resulting SPAN tag when specified" do
+      concat bootstrap_inline_label_tag("Testing", :html_options => {:"data-test" => "42"})
+      output_buffer.should have_tag("span[data-test='42']")
+    end
   end
 
   %w(success warning important notice).each do |type|


### PR DESCRIPTION
This adds the ability to pass :html_options (in the options hash) to alerts, buttons, and inline_labels. This lets you pass any arbitrary HTML options to the content_tags that are created for these various bootstrap elements. I left out navs and forms, since these seemed overly complex and I don't yet need the functionality. Updated the rdoc comments for the helpers and specs.
