### PR TITLE
Custom classes to bootstrap_navigation

### DIFF
--- a/lib/twitter-bootstrap-markup-rails/components/navigation.rb
+++ b/lib/twitter-bootstrap-markup-rails/components/navigation.rb
@@ -40,6 +40,7 @@ module Twitter::Bootstrap::Markup::Rails::Components
       classes = %w( nav )
       classes << "nav-#{ options[:type] || "tabs" }"
       classes << "nav-stacked" if options[:stacked]
+      classes << options[:custom_classes]
       classes.join(" ")
     end
   end

--- a/lib/twitter-bootstrap-markup-rails/helpers/navigation_helpers.rb
+++ b/lib/twitter-bootstrap-markup-rails/helpers/navigation_helpers.rb
@@ -8,6 +8,7 @@ module Twitter::Bootstrap::Markup::Rails::Helpers
     # @param [Hash] options hash containing options (default: {}):
     #            :type    - could be either 'tabs' or 'pills'. Default is 'tabs'.
     #            :stacked - if true, renders the navigation list in stacked mode.
+    #            :custom_classes - add additional classes to the navigation UL
     #
     # Examples
     #

--- a/spec/helpers/navigation_helpers_spec.rb
+++ b/spec/helpers/navigation_helpers_spec.rb
@@ -22,6 +22,18 @@ describe Twitter::Bootstrap::Markup::Rails::Helpers::NavigationHelpers do
       end
     end
 
+    it "should create a basic navigation list of type tabs with a custom, user specified, ID" do
+      build_bootstrap_navigation(:custom_classes => "testing") do |nav|
+        nav.link_to "Nav1", "/link1", :active_nav => true
+        nav.link_to "Nav2", "/link2"
+      end
+
+      output_buffer.should have_tag('ul.nav.nav-tabs.testing') do |ul|
+        ul.should have_tag('li[@class="active"] a[@href="/link1"]')
+        ul.should have_tag('li a[@href="/link1"]')
+      end
+    end
+
     it "should create a basic navigation list of type pills" do
       build_bootstrap_navigation(:type => "pills") do |nav|
         nav.link_to "Nav1", "/link1"


### PR DESCRIPTION
Hello everyone!

I've been moving my current project over the TBMR bit by bit. Today I discovered that my app occasionally uses custom classes in the declaration of the ul.nav.nav-tabs element.

This pull request adds support for custom classes to the `bootstrap_navigation` helper.

Please let me know if there's anything I can do to improve the patch or API, and thank you very much for twitter bootstrap markup rails -- it's saved me a ton of twitter bootstrap boilerplate!
