### PR TITLE
Enhancements for buttons

### DIFF
--- a/lib/twitter-bootstrap-markup-rails/components/button.rb
+++ b/lib/twitter-bootstrap-markup-rails/components/button.rb
@@ -2,18 +2,10 @@ module Twitter::Bootstrap::Markup::Rails::Components
   class Button < Base
     include ActionView::Helpers::UrlHelper
 
-    attr_reader :text
-
-    def initialize(text, link, options = {})
-      super
-      @text = text
-      @link = url_for(link)
-    end
-
     def to_s
       html_text = ""
       html_text << build_icon.html_safe << ' ' if options[:icon]
-      html_text << text
+      html_text << (options[:text].respond_to?(:call) ? options[:text].call : options[:text]).to_s
       html_text << ' ' << build_caret.html_safe if options[:dropdown]
 
       output_buffer << content_tag(:a, html_text.html_safe, build_tag_options).html_safe
@@ -23,6 +15,8 @@ module Twitter::Bootstrap::Markup::Rails::Components
     private
     def default_options
       {
+        :text         => nil,
+        :link         => "#",
         :class        => "btn",
         :type         => [],
         :disabled     => false,
@@ -59,10 +53,14 @@ module Twitter::Bootstrap::Markup::Rails::Components
     end
 
     def build_tag_options
-      ops = { :href => @link, :class => build_class }
+      ops = { :href => build_link, :class => build_class }
       ops[:"data-toggle"] = 'dropdown' if options[:dropdown]
       ops[:id] = options[:id] if options[:id]
       ops.reverse_merge(options[:html_options])
+    end
+
+    def build_link
+      url_for(options[:link]) if options[:link].present?
     end
   end
 end

--- a/lib/twitter-bootstrap-markup-rails/components/button_dropdown.rb
+++ b/lib/twitter-bootstrap-markup-rails/components/button_dropdown.rb
@@ -13,7 +13,7 @@ module Twitter::Bootstrap::Markup::Rails::Components
         html=''
         html << build_dropdown
 
-        html << content_tag(:ul, :class => 'dropdown-menu') do
+        html << content_tag(:ul, build_menu_html_options) do
           menu = ''
           @elements.each do |e|
             menu << content_tag(:li, e.to_s)
@@ -29,7 +29,10 @@ module Twitter::Bootstrap::Markup::Rails::Components
     private
     def default_options
       {
-        :html_options => {}
+        :html_options => {},
+        :split => false,
+        :button_options => {},
+        :menu_html_options => {}
       }
     end
 
@@ -39,13 +42,27 @@ module Twitter::Bootstrap::Markup::Rails::Components
       classes.join(" ")
     end
 
+    def build_menu_html_options
+      classes = %w(dropdown-menu)
+      classes << options[:menu_html_options][:class] if options[:menu_html_options][:class]
+
+      options[:menu_html_options].merge(:class => classes.join(" "))
+    end
+
     def build_dropdown
       html = ''
 
       if @elements.size > 0
         dropdown = @elements.shift
-        dropdown.options[:dropdown] = true
+        dropdown.options.merge!(options[:button_options])
+        dropdown.options[:dropdown] = !options[:split]
+
         html << dropdown.to_s
+
+        if options[:split]
+          caret = Button.new({:dropdown => true}.merge(options[:button_options]))
+          html << caret.to_s
+        end
       end
 
       html

--- a/lib/twitter-bootstrap-markup-rails/helpers/button_helpers.rb
+++ b/lib/twitter-bootstrap-markup-rails/helpers/button_helpers.rb
@@ -20,12 +20,20 @@ module Twitter::Bootstrap::Markup::Rails::Helpers
     #
     #   bootstrap_button 'Search', '#', :type => 'btn-primary', :icon => 'icon-search'
     #
-    def bootstrap_button(text, link, options = {})
-      Twitter::Bootstrap::Markup::Rails::Components::Button.new(
-        text,
-        link,
-        options
-      ).to_s
+    def bootstrap_button(*args, &block)
+      options = args.extract_options!
+
+      if block_given?
+        options[:text] = block
+      elsif args.present?
+        options[:text] = args.shift
+      end
+
+      if args.present?
+        options[:link] = args.shift
+      end
+
+      Twitter::Bootstrap::Markup::Rails::Components::Button.new(options).to_s
     end
 
     # Render a dropdown button

--- a/spec/helpers/button_helpers_spec.rb
+++ b/spec/helpers/button_helpers_spec.rb
@@ -61,6 +61,16 @@ describe Twitter::Bootstrap::Markup::Rails::Helpers::ButtonHelpers do
       concat bootstrap_button("Text", "#", :html_options => {:target => "_top"})
       output_buffer.should have_tag("a[target='_top']")
     end
+
+    it "should accept a block instead of text" do
+      concat bootstrap_button("#"){"<span class='content'>Text</span>"}
+      output_buffer.should have_tag("a span.content")
+    end
+
+    it "should set href to '#' if link is not given" do
+      concat bootstrap_button
+      output_buffer.should have_tag("a[href='#']")
+    end
   end
 
 

--- a/spec/helpers/button_helpers_spec.rb
+++ b/spec/helpers/button_helpers_spec.rb
@@ -108,5 +108,43 @@ describe Twitter::Bootstrap::Markup::Rails::Helpers::ButtonHelpers do
 
       output_buffer.should have_tag('div.btn-group.foo')
     end
+
+    it "should build a split dropdown if split=true" do
+      build_bootstrap_button_dropdown(:split => true) do |d|
+        d.bootstrap_button "Button Text", "#", :class => "foo"
+        d.link_to "This", "#"
+      end
+
+      output_buffer.should have_tag('div.btn-group') do |div|
+        div.should have_tag('a.foo')
+        div.should have_tag('a.dropdown-toggle')
+        # Ensure that a.foo and a.dropdown-toggle are two different links
+        div.should_not have_tag('a.foo.dropdown-toggle')
+        div.should have_tag('ul.dropdown-menu a')
+      end
+    end
+
+    it "should pass button_options to its buttons" do
+      build_bootstrap_button_dropdown(:split => true, :button_options => {:type => "btn-success"}) do |d|
+        d.bootstrap_button "Button Text", "#", :class => "foo"
+        d.link_to "This", "#"
+      end
+
+      output_buffer.should have_tag('div.btn-group') do |div|
+        div.should have_tag('a.foo.btn-success')
+        div.should have_tag('a.dropdown-toggle.btn-success')
+      end
+    end
+
+    it "should properly merge menu_html_options" do
+      build_bootstrap_button_dropdown(:menu_html_options => {:class => "pull-right"}) do |d|
+        d.bootstrap_button "Button Text", "#", :class => "foo"
+        d.link_to "This", "#"
+      end
+
+      output_buffer.should have_tag('div.btn-group') do |div|
+        div.should have_tag('ul.dropdown-menu.pull-right')
+      end
+    end
   end
 end


### PR DESCRIPTION
I just found this amazing gem for building bootstrap markup. I started converting my bootstrap code, and stumbled upon some missing features:
- `bootstrap_button`: link and text are optional. Default value for link is `"#"`, for text `""`.

``` haml
    = bootstrap_button :class => "foo"
```
- `bootstrap_button`: text can be a block

``` haml
    = bootstrap_button do
      - capture_haml do
        %span.picture
        %span.text Foo
```
- `bootstrap_button_dropdown`: support for split dropdowns

``` haml
    = bootstrap_button_dropdown :split => true do
      [...]
```
- `bootstrap_button_dropdown`: added option `button_options` that is passed to the dropdown button and its caret button (if exists)

``` haml
    = bootstrap_button_dropdown :button_options => {:type => "btn-success"} do
      [...]
```
- `bootstrap_button_dropdown`: added option `menu_html_options` that is passed to the dropdown menu

``` haml
    = bootstrap_button_dropdown :menu_html_options => {:class => "pull-right"} do
      [...]
```

What do you think, might this be interesting for others? 
