### PR TITLE
New types of inline label class: 'info' and 'inverse'

### DIFF
--- a/lib/twitter-bootstrap-markup-rails/helpers/inline_label_helpers.rb
+++ b/lib/twitter-bootstrap-markup-rails/helpers/inline_label_helpers.rb
@@ -22,7 +22,7 @@ module Twitter::Bootstrap::Markup::Rails::Helpers
       ).to_s
     end
 
-    %w(success warning important notice).each do |type|
+    %w(success warning important notice info inverse).each do |type|
       module_eval <<-EOF
         def bootstrap_inline_label_#{type}_tag(message, options = {})
           bootstrap_inline_label_tag(message, options.merge({ :type => "#{type}" }))

--- a/spec/helpers/inline_label_helpers_spec.rb
+++ b/spec/helpers/inline_label_helpers_spec.rb
@@ -24,7 +24,7 @@ describe Twitter::Bootstrap::Markup::Rails::Helpers::InlineLabelHelpers do
     end
   end
 
-  %w(success warning important notice).each do |type|
+  %w(success warning important notice info inverse).each do |type|
     describe "#inline_label_#{type}_tag" do
       before do
         @output_buffer = ''


### PR DESCRIPTION
http://twitter.github.com/bootstrap/components.html#labels-badges describes them.
`info` and `inverse` classes were missing so I added them to serve these types as well.
