### PR TITLE
fix tests: require rspec-rails instead of rspec

### DIFF
--- a/spec/support/test_environment.rb
+++ b/spec/support/test_environment.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'rspec'
+require 'rspec-rails'
 require 'rspec_tag_matchers'
 
 RSpec.configure do |config|


### PR DESCRIPTION
This should fix "no such file to load -- rspec" travis errors (which can be reproduced locally).
